### PR TITLE
Fix timing out kubernetes tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,22 @@ env:
     - CI="true"
 python: "3.6"
 stages:
-  - pre-test
+#  - pre-test
   - test
 jobs:
   include:
-    - name: "Tests postgres python 3.6"
-      env: BACKEND=postgres ENV=docker
-      python: "3.6"
-      stage: test
-    - name: "Tests sqlite python 3.5"
-      env: BACKEND=sqlite ENV=docker
-      python: "3.5"
-      stage: test
-    - name: "Tests mysql python 3.7"
-      env: BACKEND=mysql ENV=docker
-      python: "3.7"
-      stage: test
+#    - name: "Tests postgres python 3.6"
+#      env: BACKEND=postgres ENV=docker
+#      python: "3.6"
+#      stage: test
+#    - name: "Tests sqlite python 3.5"
+#      env: BACKEND=sqlite ENV=docker
+#      python: "3.5"
+#      stage: test
+#    - name: "Tests mysql python 3.7"
+#      env: BACKEND=mysql ENV=docker
+#      python: "3.7"
+#      stage: test
     - name: "Tests postgres kubernetes python 3.6 (persistent)"
       env: BACKEND=postgres ENV=kubernetes KUBERNETES_VERSION=v1.15.0 KUBERNETES_MODE=persistent_mode
       python: "3.6"
@@ -51,20 +51,20 @@ jobs:
       env: BACKEND=postgres ENV=kubernetes KUBERNETES_VERSION=v1.15.0 KUBERNETES_MODE=git_mode
       python: "3.6"
       stage: test
-    - name: "Static checks (no pylint, no licence check)"
-      stage: pre-test
-      script: ./scripts/ci/ci_run_all_static_tests_except_pylint_licence.sh
-    - name: "Check licence compliance for Apache"
-      stage: pre-test
-      script: ./scripts/ci/ci_check_license.sh
-    - name: "Pylint checks"
-      stage: pre-test
-      script: ./scripts/ci/ci_run_all_static_tests_pylint.sh
-    - name: "Build documentation"
-      stage: pre-test
-      script: ./scripts/ci/ci_docs.sh
+#    - name: "Static checks (no pylint, no licence check)"
+#      stage: pre-test
+#      script: ./scripts/ci/ci_run_all_static_tests_except_pylint_licence.sh
+#    - name: "Check licence compliance for Apache"
+#      stage: pre-test
+#      script: ./scripts/ci/ci_check_license.sh
+#    - name: "Pylint checks"
+#      stage: pre-test
+#      script: ./scripts/ci/ci_run_all_static_tests_pylint.sh
+#    - name: "Build documentation"
+#      stage: pre-test
+#      script: ./scripts/ci/ci_docs.sh
 services:
   - docker
 before_install:
   - ./scripts/ci/ci_before_install.sh
-script: "./scripts/ci/ci_run_airflow_testing.sh"
+script: travis_wait 30 "./scripts/ci/ci_run_airflow_testing.sh"

--- a/airflow/kubernetes/k8s_model.py
+++ b/airflow/kubernetes/k8s_model.py
@@ -29,6 +29,7 @@ class K8SModel(ABC):
     """
     These Airflow Kubernetes models are here for backwards compatibility
     reasons only. Ideally clients should use the kubernetes api
+
     and the process of
 
         client input -> Airflow k8s models -> k8s models


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
