### PR TITLE
Skip tests non kubernetes change

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 import copy
 import os
 import pathlib

--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -28,6 +28,14 @@ basic_sanity_checks
 
 script_start
 
+if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
+    echo
+    echo "Skipping running tests !!!!!"
+    echo
+    script_end
+    exit
+fi
+
 rebuild_ci_image_if_needed
 
 # Test environment

--- a/scripts/ci/ci_run_all_static_tests.sh
+++ b/scripts/ci/ci_run_all_static_tests.sh
@@ -31,6 +31,14 @@ basic_sanity_checks
 
 script_start
 
+if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
+    echo
+    echo "Skip tests"
+    echo
+    script_end
+    exit
+fi
+
 rebuild_ci_slim_image_if_needed
 rebuild_checklicence_image_if_needed
 

--- a/scripts/ci/ci_run_all_static_tests_except_pylint.sh
+++ b/scripts/ci/ci_run_all_static_tests_except_pylint.sh
@@ -31,6 +31,14 @@ basic_sanity_checks
 
 script_start
 
+if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
+    echo
+    echo "Skip tests"
+    echo
+    script_end
+    exit
+fi
+
 rebuild_ci_slim_image_if_needed
 rebuild_checklicence_image_if_needed
 

--- a/scripts/ci/ci_run_all_static_tests_except_pylint_licence.sh
+++ b/scripts/ci/ci_run_all_static_tests_except_pylint_licence.sh
@@ -31,6 +31,14 @@ basic_sanity_checks
 
 script_start
 
+if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
+    echo
+    echo "Skip tests"
+    echo
+    script_end
+    exit
+fi
+
 rebuild_ci_slim_image_if_needed
 
 IMAGES_TO_CHECK=("SLIM_CI")

--- a/scripts/ci/ci_run_all_static_tests_pylint.sh
+++ b/scripts/ci/ci_run_all_static_tests_pylint.sh
@@ -31,6 +31,14 @@ basic_sanity_checks
 
 script_start
 
+if [[ -f ${BUILD_CACHE_DIR}/.skip_tests ]]; then
+    echo
+    echo "Skip tests"
+    echo
+    script_end
+    exit
+fi
+
 rebuild_ci_slim_image_if_needed
 
 IMAGES_TO_CHECK=("SLIM_CI")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
