### PR TITLE
Test deadlock

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -185,7 +185,7 @@ def configure_orm(disable_connection_pool=False):
     # Allow the user to specify an encoding for their DB otherwise default
     # to utf-8 so jobs & users with non-latin1 characters can still use us.
     engine_args['encoding'] = conf.get('core', 'SQL_ENGINE_ENCODING', fallback='utf-8')
-
+    engine_args['echo'] = conf.getboolean('core', 'SQL_ENGINE_ECHO', fallback=True)
     if conf.has_option('core', 'sql_alchemy_connect_args'):
         connect_args = import_string(
             conf.get('core', 'sql_alchemy_connect_args')

--- a/tests/jobs/console.txt
+++ b/tests/jobs/console.txt
@@ -1,0 +1,89 @@
+UPDATE task_instance, dag_run SET task_instance.state=NULL
+WHERE task_instance.dag_id IN ('dag_id_1', 'dag_id_2')
+AND task_instance.state IN ('queued', 'scheduled') AND dag_run.dag_id = task_instance.dag_id
+AND dag_run.execution_date = task_instance.execution_date AND dag_run.state != 'running';
+
+
+SELECT * FROM task_instance, dag_run
+WHERE task_instance.dag_id IN ('dag_id_1', 'dag_id_2')
+  AND task_instance.state IN ('queued', 'scheduled') AND dag_run.dag_id = task_instance.dag_id
+  AND dag_run.execution_date = task_instance.execution_date; AND dag_run.state != 'running';
+
+SHOW engine innodb status;
+
+show open tables where In_Use > 0 ;
+
+SELECT state from dag_run;
+
+EXPLAIN SELECT task_instance.task_id AS task_instance_task_id, task_instance.dag_id AS
+    task_instance_dag_id, task_instance.execution_date AS task_instance_execution_date
+FROM task_instance, dag_run
+WHERE task_instance.dag_id IN ('dag_id_1', 'dag_id_2') AND
+      task_instance.state IN ('queued', 'scheduled') AND
+      dag_run.dag_id = task_instance.dag_id AND
+      dag_run.execution_date = task_instance.execution_date AND dag_run.state != 'running';
+
+
+EXPLAIN UPDATE task_instance, dag_run SET task_instance.state=NULL WHERE
+task_instance.dag_id IN ('dag_id_1', 'dag_id_2') AND task_instance.state IN ('queued', 'scheduled') AND
+dag_run.dag_id = task_instance.dag_id AND
+dag_run.execution_date = task_instance.execution_date AND dag_run.state != 'running';
+
+
+
+UPDATE task_instance,
+    (SELECT task_instance.try_number AS try_number, task_instance.task_id AS task_id,
+            task_instance.dag_id AS dag_id, task_instance.execution_date AS execution_date,
+            task_instance.start_date AS start_date, task_instance.end_date AS end_date,
+            task_instance.duration AS duration, task_instance.state AS state,
+            task_instance.max_tries AS max_tries, task_instance.hostname AS hostname,
+            task_instance.unixname AS unixname, task_instance.job_id AS job_id, task_instance.pool AS pool,
+            task_instance.queue AS queue,
+            task_instance.priority_weight AS priority_weight, task_instance.operator AS operator,
+            task_instance.queued_dttm AS queued_dttm,
+            task_instance.pid AS pid, task_instance.executor_config AS executor_config
+    FROM task_instance LEFT OUTER JOIN dag_run ON task_instance.dag_id = dag_run.dag_id
+                                AND task_instance.execution_date = dag_run.execution_date
+                       WHERE task_instance.dag_id IN ('dag_id_1', 'dag_id_2') AND
+                             task_instance.state IN ('queued', 'scheduled') AND
+                             (dag_run.state != 'running' OR dag_run.state IS NULL)) AS anon_1
+                SET task_instance.state=NULL WHERE task_instance.dag_id = anon_1.dag_id
+                AND task_instance.task_id = anon_1.task_id AND task_instance.execution_date = anon_1.execution_date;
+
+
+UPDATE performance_schema.setup_instruments
+SET enabled = 'YES'
+WHERE name = 'wait/lock/metadata/sql/mdl';
+
+SELECT
+    pl.id
+     ,pl.user
+     ,pl.state
+     ,it.trx_id
+     ,it.trx_mysql_thread_id
+     ,it.trx_query AS query
+     ,it.trx_id AS blocking_trx_id
+     ,it.trx_mysql_thread_id AS blocking_thread
+     ,it.trx_query AS blocking_query
+FROM information_schema.processlist AS pl
+         INNER JOIN information_schema.innodb_trx AS it
+                    ON pl.id = it.trx_mysql_thread_id
+         INNER JOIN information_schema.innodb_lock_waits AS ilw
+                    ON it.trx_id = ilw.requesting_trx_id
+                        AND it.trx_id = ilw.blocking_trx_id;
+
+
+SHOW OPEN TABLES IN AIRFLOW;
+
+SELECT * FROM information_schema.innodb_lock_waits;
+
+Select * from mysql.general_log;
+
+SET GLOBAL log_output = 'TABLE';
+SET GLOBAL general_log = 'ON';
+
+SELECT Table_schema, Table_Name, Column_Name
+FROM Information_Schema.Columns
+Where (Table_Schema = 'information_schema'
+    or Table_Schema = 'sys')
+  AND Column_Name like '%lock%';


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
