### PR TITLE
Speed up verification and instalation of providers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
       cache-directive: ${{ steps.selective-checks.outputs.cache-directive }}
+      affected-providers: ${{ steps.selective-checks.outputs.affected-providers }}
       upgrade-to-newer-dependencies: ${{ steps.selective-checks.outputs.upgrade-to-newer-dependencies }}
       python-versions: ${{ steps.selective-checks.outputs.python-versions }}
       python-versions-list-as-string: ${{ steps.selective-checks.outputs.python-versions-list-as-string }}
@@ -728,11 +729,13 @@ jobs:
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*
       - name: "Prepare provider documentation"
-        run: breeze release-management prepare-provider-documentation
+        run: >
+          breeze release-management prepare-provider-documentation
+          ${{ needs.build-info.outputs.affected-providers }}
       - name: "Prepare provider packages: wheel"
         run: >
           breeze release-management prepare-provider-packages --version-suffix-for-pypi dev0
-          --package-format wheel
+          --package-format wheel ${{ needs.build-info.outputs.affected-providers }}
       - name: "Prepare airflow package: wheel"
         run: breeze release-management prepare-airflow-package --version-suffix-for-pypi dev0
       - name: "Verify wheel packages with twine"
@@ -741,10 +744,18 @@ jobs:
         run: >
           breeze release-management generate-issue-content-providers
           --only-available-in-dist --disable-progress
-      - name: "Install and test provider packages and airflow via wheel files"
+      - name: "Install and verify all provider packages and airflow via wheel files"
         run: >
           breeze release-management verify-provider-packages --use-packages-from-dist
           --package-format wheel --use-airflow-version wheel
+        if: needs.build-info.outputs.affected-providers == ''
+        env:
+          SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
+      - name: "Install affected provider packages and airflow via wheel files"
+        run: >
+          breeze release-management install-provider-packages --use-packages-from-dist
+          --package-format wheel --use-airflow-version wheel --run-in-parallel
+        if: needs.build-info.outputs.affected-providers != ''
         env:
           SKIP_CONSTRAINTS: "${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}"
       - name: "Fix ownership"
@@ -776,7 +787,7 @@ jobs:
       - name: "Prepare provider packages: wheel"
         run: >
           breeze release-management prepare-provider-packages --version-suffix-for-pypi dev0
-          --package-format wheel
+          --package-format wheel ${{ needs.build-info.outputs.affected-providers }}
       - name: "Fix incompatible 2.3 provider packages"
         run: |
           # This step should remove the provider packages that are not compatible with 2.3
@@ -801,10 +812,17 @@ jobs:
           providers = json.loads(Path("generated/provider_dependencies.json").read_text())
           provider_keys = ",".join(providers.keys())
           print("AIRFLOW_EXTRAS={}".format(provider_keys))' >> $GITHUB_ENV
-      - name: "Install and verify provider packages and airflow on Airflow 2.3 files"
+      - name: "Install and verify all provider packages and airflow on Airflow 2.3 files"
         run: >
           breeze release-management verify-provider-packages --use-airflow-version 2.3.0
           --use-packages-from-dist --airflow-constraints-reference constraints-2.3.0
+        if: needs.build-info.outputs.affected-providers == ''
+      - name: "Install affected provider packages and airflow on Airflow 2.3 files"
+        run: >
+          breeze release-management install-provider-packages --use-airflow-version 2.3.0
+          --use-packages-from-dist --airflow-constraints-reference constraints-2.3.0 --run-in-parallel
+          ${{ needs.build-info.outputs.affected-providers }}
+        if: needs.build-info.outputs.affected-providers != ''
       - name: "Fix ownership"
         run: breeze ci fix-ownership
         if: always()
@@ -834,19 +852,24 @@ jobs:
       - name: "Prepare provider packages: sdist"
         run: >
           breeze release-management prepare-provider-packages
-          --version-suffix-for-pypi dev0
-          --package-format sdist
+          --version-suffix-for-pypi dev0 --package-format sdist
+          ${{ needs.build-info.outputs.affected-providers }}
       - name: "Prepare airflow package: sdist"
         run: >
           breeze release-management prepare-airflow-package
-          --version-suffix-for-pypi dev0
-          --package-format sdist
+          --version-suffix-for-pypi dev0 --package-format sdist
       - name: "Verify sdist packages with twine"
         run: pipx install twine --force && twine check dist/*.tar.gz
-      - name: "Install provider packages and airflow via sdist files"
+      - name: "Install all provider packages and airflow via sdist files"
         run: >
           breeze release-management install-provider-packages
           --package-format sdist --use-airflow-version sdist --run-in-parallel
+        if: needs.build-info.outputs.affected-providers == ''
+      - name: "Install affected provider packages and airflow via sdist files"
+        run: >
+          breeze release-management install-provider-packages
+          --package-format sdist --use-airflow-version sdist --run-in-parallel
+        if: needs.build-info.outputs.affected-providers != ''
       - name: "Fix ownership"
         run: breeze ci fix-ownership
         if: always()

--- a/dev/breeze/SELECTIVE_CHECKS.md
+++ b/dev/breeze/SELECTIVE_CHECKS.md
@@ -113,6 +113,7 @@ The selective check outputs available are described below:
 
 | Output                             | Meaning of the output                                                                                   | Example value                                       |
 |------------------------------------|---------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| affected-providers                 | List of providers affected when they are selectively affected. Empty if no or all providers affected.   | airbyte http                                        |
 | all-python-versions                | List of all python versions there are available in the form of JSON array                               | ['3.7', '3.8', '3.9', '3.10']                       |
 | all-python-versions-list-as-string | List of all python versions there are available in the form of space separated string                   | 3.7 3.8 3.9 3.10                                    |
 | basic-checks-only                  | Whether to run all static checks ("false") or only basic set of static checks ("true")                  | false                                               |

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -46,6 +46,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("INTHEWILD.md",),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -65,6 +66,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("airflow/api/file.py",),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -87,6 +89,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/postgres/file.py",
                 ),
                 {
+                    "affected-providers": "amazon common.sql google postgres",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -107,6 +110,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("tests/providers/apache/beam/file.py",),
                 {
+                    "affected-providers": "apache.beam google",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -127,6 +131,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("docs/file.rst",),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -150,6 +155,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/postgres/file.py",
                 ),
                 {
+                    "affected-providers": "amazon common.sql google postgres",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -176,6 +182,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/http/file.py",
                 ),
                 {
+                    "affected-providers": "airbyte apache.livy dbt.cloud dingding discord http",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -202,6 +209,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/providers/airbyte/file.py",
                 ),
                 {
+                    "affected-providers": "airbyte http",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -227,6 +235,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "tests/system/utils/file.py",
                 ),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
                     "python-versions": "['3.7']",
@@ -247,6 +256,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("setup.py",),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -268,6 +278,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             pytest.param(
                 ("generated/provider_dependencies.json",),
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -287,6 +298,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
         pytest.param(
             ("airflow/providers/amazon/__init__.py",),
             {
+                "affected-providers": "amazon apache.hive cncf.kubernetes common.sql exasol ftp google imap "
+                "mongo mysql postgres salesforce ssh",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "python-versions": "['3.7']",
@@ -307,6 +320,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
         pytest.param(
             ("tests/providers/airbyte/__init__.py",),
             {
+                "affected-providers": "airbyte http",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "python-versions": "['3.7']",
@@ -325,6 +339,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
         pytest.param(
             ("airflow/providers/amazon/file.py",),
             {
+                "affected-providers": "amazon apache.hive cncf.kubernetes common.sql exasol ftp google imap "
+                "mongo mysql postgres salesforce ssh",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "python-versions": "['3.7']",
@@ -367,6 +383,7 @@ def test_expected_output_pull_request_main(
                 ("full tests needed",),
                 "main",
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -392,6 +409,7 @@ def test_expected_output_pull_request_main(
                 ),
                 "main",
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -415,6 +433,7 @@ def test_expected_output_pull_request_main(
                 ("full tests needed",),
                 "main",
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -438,6 +457,7 @@ def test_expected_output_pull_request_main(
                 ("full tests needed",),
                 "v2-3-stable",
                 {
+                    "affected-providers": "",
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "python-versions": "['3.7', '3.8', '3.9', '3.10']",
@@ -445,6 +465,7 @@ def test_expected_output_pull_request_main(
                     "image-build": "true",
                     "run-tests": "true",
                     "docs-build": "true",
+                    "docs-filter": "--package-filter apache-airflow --package-filter docker-stack",
                     "full-tests-needed": "true",
                     "upgrade-to-newer-dependencies": "false",
                     "parallel-test-types": "Core Other WWW API Always CLI",
@@ -476,12 +497,14 @@ def test_expected_output_full_tests_needed(
         pytest.param(
             ("INTHEWILD.md",),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "false",
                 "needs-helm-tests": "false",
                 "run-tests": "false",
                 "docs-build": "false",
+                "docs-filter": "--package-filter apache-airflow --package-filter docker-stack",
                 "full-tests-needed": "false",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-provider-tests": "true",
@@ -495,12 +518,14 @@ def test_expected_output_full_tests_needed(
                 "tests/providers/google/file.py",
             ),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "needs-helm-tests": "false",
                 "image-build": "true",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "--package-filter apache-airflow --package-filter docker-stack",
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
@@ -516,12 +541,14 @@ def test_expected_output_full_tests_needed(
                 "tests/providers/google/file.py",
             ),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "true",
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "--package-filter apache-airflow --package-filter docker-stack",
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
@@ -536,12 +563,14 @@ def test_expected_output_full_tests_needed(
                 "tests/providers/google/file.py",
             ),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "true",
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "--package-filter apache-airflow --package-filter docker-stack",
                 "full-tests-needed": "false",
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
@@ -572,12 +601,14 @@ def test_expected_output_pull_request_v2_3(
         pytest.param(
             ("INTHEWILD.md",),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "false",
                 "needs-helm-tests": "false",
                 "run-tests": "false",
                 "docs-build": "false",
+                "docs-filter": "",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-provider-tests": "false",
                 "parallel-test-types": "",
@@ -587,12 +618,14 @@ def test_expected_output_pull_request_v2_3(
         pytest.param(
             ("tests/system/any_file.py",),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "true",
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-provider-tests": "false",
                 "parallel-test-types": "Always",
@@ -606,12 +639,34 @@ def test_expected_output_pull_request_v2_3(
                 "tests/providers/google/file.py",
             ),
             {
+                "affected-providers": "amazon apache.beam apache.cassandra cncf.kubernetes common.sql "
+                "facebook google hashicorp microsoft.azure microsoft.mssql mysql "
+                "oracle postgres presto salesforce sftp ssh trino",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "true",
                 "needs-helm-tests": "true",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "--package-filter apache-airflow --package-filter helm-chart "
+                "--package-filter apache-airflow-providers-amazon "
+                "--package-filter apache-airflow-providers-apache-beam "
+                "--package-filter apache-airflow-providers-apache-cassandra "
+                "--package-filter apache-airflow-providers-cncf-kubernetes "
+                "--package-filter apache-airflow-providers-common-sql "
+                "--package-filter apache-airflow-providers-facebook "
+                "--package-filter apache-airflow-providers-google "
+                "--package-filter apache-airflow-providers-hashicorp "
+                "--package-filter apache-airflow-providers-microsoft-azure "
+                "--package-filter apache-airflow-providers-microsoft-mssql "
+                "--package-filter apache-airflow-providers-mysql "
+                "--package-filter apache-airflow-providers-oracle "
+                "--package-filter apache-airflow-providers-postgres "
+                "--package-filter apache-airflow-providers-presto "
+                "--package-filter apache-airflow-providers-salesforce "
+                "--package-filter apache-airflow-providers-sftp "
+                "--package-filter apache-airflow-providers-ssh "
+                "--package-filter apache-airflow-providers-trino",
                 "run-kubernetes-tests": "true",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-provider-tests": "false",
@@ -628,12 +683,14 @@ def test_expected_output_pull_request_v2_3(
                 "tests/providers/google/file.py",
             ),
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7']",
                 "all-python-versions-list-as-string": "3.7",
                 "image-build": "true",
                 "needs-helm-tests": "false",
                 "run-tests": "true",
                 "docs-build": "true",
+                "docs-filter": "",
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
                 "skip-provider-tests": "false",
@@ -666,6 +723,7 @@ def test_expected_output_pull_request_target(
             (),
             "main",
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                 "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                 "image-build": "true",
@@ -684,6 +742,7 @@ def test_expected_output_pull_request_target(
             (),
             "v2-3-stable",
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                 "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                 "image-build": "true",
@@ -702,6 +761,7 @@ def test_expected_output_pull_request_target(
             (),
             "main",
             {
+                "affected-providers": "",
                 "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                 "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                 "image-build": "true",
@@ -904,9 +964,9 @@ def test_upgrade_to_newer_dependencies(files: tuple[str, ...], expected_outputs:
         pytest.param(
             ("airflow/test.py",),
             {
-                "docs-filter": "--package-filter apache-airflow",
+                "docs-filter": "",
             },
-            id="Core files changed. No provider docs to build",
+            id="Core files changed. All provider docs should also be built",
         ),
         pytest.param(
             ("docs/docker-stack/test.rst",),
@@ -916,9 +976,9 @@ def test_upgrade_to_newer_dependencies(files: tuple[str, ...], expected_outputs:
         pytest.param(
             ("airflow/test.py", "chart/airflow/values.yaml"),
             {
-                "docs-filter": "--package-filter apache-airflow --package-filter helm-chart",
+                "docs-filter": "",
             },
-            id="Core files and helm chart files changed. No provider docs to build",
+            id="Core files and helm chart files changed. All provider docs should be built",
         ),
         pytest.param(
             ("chart/airflow/values.yaml",),


### PR DESCRIPTION
For PRs that are just changing selected providers, there is no need to install and verify all providers, just those affected should be installed (and full verification should only be done when all providers are being built - so generally speaking, when Core PRs are run or when canary builds are run.

This PR distinguishes those two cases:

* installing and verification when all providers are selected
* installing only affected providers when only subset of them are affected

Also a bug was found where core file changes did not trigger provider docs build during implementation. This has been fixed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
